### PR TITLE
Make confidence parameter optional in N.CI and LN.CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## About GaussFormula
 
-**GaussFormula** is a headless spreadsheet engine for JavaScript and TypeScript, designed for business and scientific web applications. It is a fork of HyperFormula with native support for uncertainty through explicit probability distributions such as `N(mean, variance)`, `LN(mu, sigma)`, `U(min, max)`, `N.CI(lower, upper, confidence)`, and `LN.CI(lower, upper, confidence)`.
+**GaussFormula** is a headless spreadsheet engine for JavaScript and TypeScript, designed for business and scientific web applications. It is a fork of HyperFormula with native support for uncertainty through explicit probability distributions such as `N(mean, variance)`, `LN(mu, sigma)`, `U(min, max)`, `N.CI(lower, upper[, confidence])`, and `LN.CI(lower, upper[, confidence])`.
 
 GaussFormula is ideal for:
 - Custom spreadsheet-like apps
@@ -58,7 +58,7 @@ const gf = HyperFormula.buildEmpty({ licenseKey: 'gpl-v3' });
 const sheetName = gf.addSheet('Demo');
 const sheetId = gf.getSheetId(sheetName);
 
-gf.setCellContents({ sheet: sheetId, row: 0, col: 0 }, [['N.CI(1, 2, 0.95)', '3', '=A1+B1', '=A1*B1']]);
+gf.setCellContents({ sheet: sheetId, row: 0, col: 0 }, [['N.CI(1, 2)', '3', '=A1+B1', '=A1*B1']]);
 
 console.log(gf.getCellValue({ sheet: sheetId, row: 0, col: 2 })); // SampledDistribution
 console.log(gf.getCellValue({ sheet: sheetId, row: 0, col: 3 })); // SampledDistribution
@@ -74,13 +74,13 @@ GaussFormula extends HyperFormula with first-class support for explicit uncertai
 
 - `N(mean, variance)` uses normal-distribution parameters directly.
 - `LN(mu, sigma)` uses log-space parameters: if `X ~ LN(mu, sigma)`, then `ln(X) ~ N(mu, sigma^2)`. `mu` and `sigma` are not the mean and standard deviation of `X`.
-- Prefer `LN.CI(lower, upper, confidence)` for user-facing lognormal inputs because the bounds are in the original value scale.
-- `N.CI(lower, upper, confidence)` derives a normal distribution from a value-scale confidence interval.
+- Prefer `LN.CI(lower, upper[, confidence])` for user-facing lognormal inputs because the bounds are in the original value scale.
+- `N.CI(lower, upper[, confidence])` derives a normal distribution from a value-scale confidence interval.
 - `U(min, max)` represents a uniform range on the original value scale.
 
 **Example:**
 
-- `A1 -> N.CI(1, 2, 0.95)`
+- `A1 -> N.CI(1, 2)`
 - `=A1 + 3` returns a sampled distribution
 - `=A1 * 3` returns a sampled distribution
 

--- a/docs/features/uncertainty-sampling/aggregate-functions.md
+++ b/docs/features/uncertainty-sampling/aggregate-functions.md
@@ -7,8 +7,8 @@ the aggregate should be evaluated once per simulation trial and should return a
 For example:
 
 ```text
-A1 = N.CI(10, 20, 0.95)
-A2 = N.CI(30, 40, 0.95)
+A1 = N.CI(10, 20)
+A2 = N.CI(30, 40)
 =SUM(A1:A2)
 ```
 

--- a/docs/features/uncertainty-sampling/pointwise-functions.md
+++ b/docs/features/uncertainty-sampling/pointwise-functions.md
@@ -7,7 +7,7 @@ simulation trial and returns a `SampledDistribution`.
 For example:
 
 ```text
-A1 = N.CI(1, 2, 0.95)
+A1 = N.CI(1, 2)
 =SQRT(A1)
 ```
 

--- a/docs/features/uncertainty-sampling/statistical-aggregate-functions.md
+++ b/docs/features/uncertainty-sampling/statistical-aggregate-functions.md
@@ -7,8 +7,8 @@ and returns a `SampledDistribution`.
 For example:
 
 ```text
-A1 = N.CI(10, 20, 0.95)
-A2 = N.CI(30, 40, 0.95)
+A1 = N.CI(10, 20)
+A2 = N.CI(30, 40)
 =STDEV.S(A1:A2)
 ```
 

--- a/src/NumberLiteralHelper.ts
+++ b/src/NumberLiteralHelper.ts
@@ -11,6 +11,8 @@ import {
 import { Config } from './Config'
 import { Maybe } from './Maybe'
 
+const DEFAULT_CONFIDENCE_LEVEL = 95
+
 export class NumberLiteralHelper {
   private readonly numberPattern: RegExp
   private readonly allThousandSeparatorsRegex: RegExp
@@ -23,9 +25,9 @@ export class NumberLiteralHelper {
   private readonly uniformPattern: RegExp =
     /^U\s*\(\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\)$/i
   private readonly normalCiPattern: RegExp =
-    /^N\.CI\s*\(\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\)$/i
+    /^N\.CI\s*\(\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)(?:\s*,\s*([+-]?\d*\.?\d+))?\s*\)$/i
   private readonly lognormalCiPattern: RegExp =
-    /^LN\.CI\s*\(\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)\s*\)$/i
+    /^LN\.CI\s*\(\s*([+-]?\d*\.?\d+)\s*,\s*([+-]?\d*\.?\d+)(?:\s*,\s*([+-]?\d*\.?\d+))?\s*\)$/i
 
   constructor(private readonly config: Config) {
     const thousandSeparator =
@@ -115,7 +117,9 @@ export class NumberLiteralHelper {
     if (normalCiMatch) {
       const lower = Number(normalCiMatch[1])
       const upper = Number(normalCiMatch[2])
-      const confidence = Number(normalCiMatch[3])
+      const confidence = normalCiMatch[3] === undefined
+        ? DEFAULT_CONFIDENCE_LEVEL
+        : Number(normalCiMatch[3])
       if (this.isValidConfidenceInterval(lower, upper, confidence)) {
         return DistributionNumber.normalFromCI(lower, upper, confidence)
       }
@@ -126,7 +130,9 @@ export class NumberLiteralHelper {
     if (lognormalCiMatch) {
       const lower = Number(lognormalCiMatch[1])
       const upper = Number(lognormalCiMatch[2])
-      const confidence = Number(lognormalCiMatch[3])
+      const confidence = lognormalCiMatch[3] === undefined
+        ? DEFAULT_CONFIDENCE_LEVEL
+        : Number(lognormalCiMatch[3])
       if (
         this.isValidConfidenceInterval(lower, upper, confidence) &&
         lower > 0

--- a/src/Serialization.ts
+++ b/src/Serialization.ts
@@ -11,6 +11,7 @@ import {
 } from './DependencyGraph'
 import { CellError, ErrorType } from './Cell'
 import {
+  DEFAULT_CONFIDENCE_LEVEL,
   DistributionNumber,
   EmptyValue,
   InterpreterValue,
@@ -130,15 +131,18 @@ export class Serialization {
     const confidence = value.confidenceLevel === undefined
       ? undefined
       : (value.confidenceLevel > 1 ? value.confidenceLevel / 100 : value.confidenceLevel)
+    const confidenceArgument = value.confidenceLevel === DEFAULT_CONFIDENCE_LEVEL
+      ? ''
+      : `, ${confidence?.toFixed(2)}`
     switch (value.kind) {
       case 'normal':
         if (value.source === 'ci' && value.lower !== undefined && value.upper !== undefined && value.confidenceLevel !== undefined) {
-          return `N.CI(${value.lower.toFixed(2)}, ${value.upper.toFixed(2)}, ${confidence?.toFixed(2)})`
+          return `N.CI(${value.lower.toFixed(2)}, ${value.upper.toFixed(2)}${confidenceArgument})`
         }
         return `N(${(value.mean ?? 0).toFixed(2)}, ${(value.variance ?? 0).toFixed(2)})`
       case 'lognormal':
         if (value.source === 'ci' && value.lower !== undefined && value.upper !== undefined && value.confidenceLevel !== undefined) {
-          return `LN.CI(${value.lower.toFixed(2)}, ${value.upper.toFixed(2)}, ${confidence?.toFixed(2)})`
+          return `LN.CI(${value.lower.toFixed(2)}, ${value.upper.toFixed(2)}${confidenceArgument})`
         }
         return `LN(${(value.mu ?? 0).toFixed(2)}, ${(value.sigma ?? 0).toFixed(2)})`
       case 'uniform':

--- a/src/interpreter/InterpreterValue.ts
+++ b/src/interpreter/InterpreterValue.ts
@@ -208,6 +208,8 @@ export function sampleUniformDistribution(
 export type DistributionKind = 'normal' | 'lognormal' | 'uniform'
 export type DistributionSource = 'parameters' | 'ci'
 
+export const DEFAULT_CONFIDENCE_LEVEL = 95
+
 type DistributionNumberOptions = {
   format?: string,
   samplingIdentity?: string,
@@ -296,7 +298,7 @@ export class DistributionNumber extends RichNumber {
   public static normalFromCI(
     lower: number,
     upper: number,
-    confidence: number,
+    confidence: number = DEFAULT_CONFIDENCE_LEVEL,
     options?: DistributionNumberOptions
   ): DistributionNumber {
     const confidenceLevel = normalizeConfidenceLevel(confidence)
@@ -315,7 +317,7 @@ export class DistributionNumber extends RichNumber {
   public static lognormalFromCI(
     lower: number,
     upper: number,
-    confidence: number,
+    confidence: number = DEFAULT_CONFIDENCE_LEVEL,
     options?: DistributionNumberOptions
   ): DistributionNumber {
     const confidenceLevel = normalizeConfidenceLevel(confidence)

--- a/src/interpreter/plugin/DistributionPlugin.ts
+++ b/src/interpreter/plugin/DistributionPlugin.ts
@@ -7,7 +7,7 @@ import {CellError, ErrorType} from '../../Cell'
 import {ErrorMessage} from '../../error-message'
 import {ProcedureAst} from '../../parser/Ast'
 import {InterpreterState} from '../InterpreterState'
-import {DistributionNumber, InterpreterValue} from '../InterpreterValue'
+import {DEFAULT_CONFIDENCE_LEVEL, DistributionNumber, InterpreterValue} from '../InterpreterValue'
 import {FunctionArgumentType, FunctionPlugin, FunctionPluginTypecheck, ImplementedFunctions} from './FunctionPlugin'
 
 export class DistributionPlugin extends FunctionPlugin implements FunctionPluginTypecheck<DistributionPlugin> {
@@ -31,7 +31,7 @@ export class DistributionPlugin extends FunctionPlugin implements FunctionPlugin
       parameters: [
         {argumentType: FunctionArgumentType.NUMBER},
         {argumentType: FunctionArgumentType.NUMBER},
-        {argumentType: FunctionArgumentType.NUMBER, greaterThan: 0, lessThan: 100},
+        {argumentType: FunctionArgumentType.NUMBER, greaterThan: 0, lessThan: 100, defaultValue: DEFAULT_CONFIDENCE_LEVEL},
       ],
     },
     'LN.CI': {
@@ -39,7 +39,7 @@ export class DistributionPlugin extends FunctionPlugin implements FunctionPlugin
       parameters: [
         {argumentType: FunctionArgumentType.NUMBER},
         {argumentType: FunctionArgumentType.NUMBER},
-        {argumentType: FunctionArgumentType.NUMBER, greaterThan: 0, lessThan: 100},
+        {argumentType: FunctionArgumentType.NUMBER, greaterThan: 0, lessThan: 100, defaultValue: DEFAULT_CONFIDENCE_LEVEL},
       ],
     },
   }

--- a/test/interpreter/distribution-constructors.spec.ts
+++ b/test/interpreter/distribution-constructors.spec.ts
@@ -48,13 +48,38 @@ describe('explicit distribution constructors', () => {
     expect(normal.variance).toBeCloseTo(Math.pow(1 / (2 * zScore95), 2), 12)
     expect(normal.source).toBe('ci')
     expect(normal.confidenceLevel).toBe(95)
-    expect(engine.getCellSerialized(adr('A1'))).toBe('N.CI(1.00, 2.00, 0.95)')
+    expect(engine.getCellSerialized(adr('A1'))).toBe('N.CI(1.00, 2.00)')
 
     expect(lognormal.mu).toBeCloseTo(Math.log(2) / 2, 8)
     expect(lognormal.sigma).toBeCloseTo(Math.log(2) / (2 * zScore95), 12)
     expect(lognormal.source).toBe('ci')
     expect(lognormal.confidenceLevel).toBe(95)
-    expect(engine.getCellSerialized(adr('B1'))).toBe('LN.CI(1.00, 2.00, 0.95)')
+    expect(engine.getCellSerialized(adr('B1'))).toBe('LN.CI(1.00, 2.00)')
+  })
+
+  it('defaults confidence interval constructors to 95 percent when confidence is omitted', () => {
+    const engine = HyperFormula.buildFromArray([
+      ['N.CI(1, 2)', 'LN.CI(1, 2)', '=N.CI(1, 2)+1', '=LN.CI(1, 2)+1'],
+    ])
+
+    const normal = expectDistribution(engine.getCellValue(adr('A1')), 'normal')
+    const lognormal = expectDistribution(engine.getCellValue(adr('B1')), 'lognormal')
+    const zScore95 = 1.9599639845400545
+
+    expect(normal.mean).toBe(1.5)
+    expect(normal.variance).toBeCloseTo(Math.pow(1 / (2 * zScore95), 2), 12)
+    expect(normal.source).toBe('ci')
+    expect(normal.confidenceLevel).toBe(95)
+    expect(engine.getCellSerialized(adr('A1'))).toBe('N.CI(1.00, 2.00)')
+
+    expect(lognormal.mu).toBeCloseTo(Math.log(2) / 2, 8)
+    expect(lognormal.sigma).toBeCloseTo(Math.log(2) / (2 * zScore95), 12)
+    expect(lognormal.source).toBe('ci')
+    expect(lognormal.confidenceLevel).toBe(95)
+    expect(engine.getCellSerialized(adr('B1'))).toBe('LN.CI(1.00, 2.00)')
+
+    expect(engine.getCellValue(adr('C1'))).toBeInstanceOf(SampledDistribution)
+    expect(engine.getCellValue(adr('D1'))).toBeInstanceOf(SampledDistribution)
   })
 
   it('uses the exact normal quantile for non-table confidence levels', () => {
@@ -69,6 +94,7 @@ describe('explicit distribution constructors', () => {
     expect(normal.mean).toBe(20)
     expect(normal.variance).toBeCloseTo(std * std, 12)
     expect(normal.confidenceLevel).toBe(93)
+    expect(engine.getCellSerialized(adr('A1'))).toBe('N.CI(18.00, 22.00, 0.93)')
   })
 
   it('supports explicit distribution constructors inside formulas', () => {
@@ -83,7 +109,7 @@ describe('explicit distribution constructors', () => {
 
   it('propagates explicit distribution cell references through arithmetic', () => {
     const engine = HyperFormula.buildFromArray([
-      ['N.CI(18, 22, 0.95)', '=A1*2', '=A1+2', '=A1/2'],
+      ['N.CI(18, 22)', '=A1*2', '=A1+2', '=A1/2'],
     ])
 
     expect(engine.getCellValue(adr('A1'))).toBeInstanceOf(DistributionNumber)

--- a/test/visual-dependency-graph.spec.ts
+++ b/test/visual-dependency-graph.spec.ts
@@ -57,7 +57,7 @@ describe('GaussFormula.getVisualDependencyGraph', () => {
   })
 
   it('returns structured distribution and sampled distribution summaries', () => {
-    const engine = GaussFormula.buildFromArray([['N.CI(10, 20, 0.95)', '=A1*2']], {
+    const engine = GaussFormula.buildFromArray([['N.CI(10, 20)', '=A1*2']], {
       sampleSize: 1000,
     })
 


### PR DESCRIPTION
The third parameter (confidence level) now defaults to 95% when omitted. Updated regex patterns to make the parameter optional, added a DEFAULT_CONFIDENCE_LEVEL constant, and updated serialization to omit the confidence argument when it equals the default value.

### Context
<!--- Why are your changes required? What problem do they solve? -->

### How did you test your changes?
<!--- Describe in detail how you tested your changes. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in each box that applies. -->
- [ ] Breaking change (a fix or a feature because of which an existing functionality doesn't work as expected anymore)
- [ ] New feature or improvement (a non-breaking change that adds functionality)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Additional language file, or a change to an existing language file (translations)
- [ ] Change to the documentation

### Related issues:
1. Fixes #...
2.
3.

### Checklist:
<!--- Go through the points below, and put an `x` in each box that applies. -->
<!--- If you're unsure about any of these, contact us. We're always glad to help! -->
- [ ] I have reviewed the guidelines about [Contributing to HyperFormula](https://hyperformula.handsontable.com/guide/contributing.html) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://goo.gl/forms/yuutGuN0RjsikVpM2).
- [ ] My change is compliant with the [OpenDocument](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html) standard.
- [ ] My change is compatible with Microsoft Excel.
- [ ] My change is compatible with Google Sheets.
- [ ] I described my changes in the [CHANGELOG.md](https://github.com/handsontable/hyperformula/blob/master/CHANGELOG.md) file.
- [ ] My changes require a documentation update.
- [ ] My changes require a migration guide.
